### PR TITLE
Add a registry of agent abstract factory to create them 

### DIFF
--- a/ProjetINFRA/src/main/java/fr/m2dl/infra/AgentFactoriesRegistry.java
+++ b/ProjetINFRA/src/main/java/fr/m2dl/infra/AgentFactoriesRegistry.java
@@ -1,0 +1,61 @@
+package fr.m2dl.infra;
+
+import fr.m2dl.infra.IFactoryAgent;
+import fr.m2dl.infra.Agent;
+import java.util.*;
+
+/**
+ * Define a registry of abstract factory which produce agents.
+ *
+ * @author Infra core team
+ * @since 15-02-2018
+ */
+public class AgentFactoriesRegistry {
+    private Map<Integer, IFactoryAgent<Agent>> factories;
+    private int indexFactory;
+
+    public AgentFactoriesRegistry() {
+        this.factories = new HashMap<>();
+        this.indexFactory = 0;
+    }
+
+    public Optional<Agent> createAgent(int token) {
+        return getFactoryImpl(token)
+                .map(IFactoryAgent::create);
+    }
+
+    public Optional<List<Agent>> createSwarm(int token, long count) {
+        return getFactoryImpl(token)
+                .map(f -> createAgents(f, count));
+    }
+
+    public int registerAgentFactory(IFactoryAgent factory) {
+        int token = this.indexFactory;
+        this.factories.put(token, factory);
+        this.indexFactory += 1;
+
+        return token;
+    }
+
+    public int getNbOfFactories() {
+        return this.factories.size();
+    }
+
+    private List<Agent> createAgents(IFactoryAgent factory, long count) {
+        ArrayList<Agent> agents = new ArrayList<>();
+
+        for (int i = 0; i < count; i++)
+            agents.add(factory.create());
+
+        return agents;
+    }
+
+    private Optional<IFactoryAgent> getFactoryImpl(int token) {
+        IFactoryAgent factory = factories.get(token);
+
+        if (factory != null)
+            return Optional.of(factory);
+        else
+            return Optional.empty();
+    }
+}

--- a/ProjetINFRA/src/main/java/fr/m2dl/infra/IFactoryAgent.java
+++ b/ProjetINFRA/src/main/java/fr/m2dl/infra/IFactoryAgent.java
@@ -1,0 +1,13 @@
+package fr.m2dl.infra;
+
+import fr.m2dl.infra.Agent;
+
+/**
+ * Define an factory to produce agent.
+ *
+ * @author Infra core team
+ * @since 15-02-2018
+ */
+public interface IFactoryAgent<A extends Agent> {
+    A create();
+}

--- a/ProjetINFRA/src/main/java/fr/m2dl/infra/Orchestrator.java
+++ b/ProjetINFRA/src/main/java/fr/m2dl/infra/Orchestrator.java
@@ -2,23 +2,26 @@ package fr.m2dl.infra;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Scheduler of the Multi-Agent System
  *
  * It "runs" all the agents in the system
  * @author Infra core team
- * @since 02-02-2018
+ * @since 16-02-2018
  */
 public class Orchestrator {
     List<ActiveEntity> activeEntityList;
     List<Agent> agentList;
+    AgentFactoriesRegistry registryFactories;
 
     /**
      * Default constructor
      */
     public Orchestrator() {
         agentList = new ArrayList<Agent>();
+        registryFactories = new AgentFactoriesRegistry();
     }
 
     /**
@@ -27,6 +30,44 @@ public class Orchestrator {
      */
     public void createAgent(Agent agent) {
         agentList.add(agent);
+    }
+
+    /**
+     * Register a new factory to create agent
+     * @param factory the factory that can create Agent
+     */
+    public int addFactoryOfAgent(IFactoryAgent<Agent> factory) {
+        return this.registryFactories.registerAgentFactory(factory);
+    }
+
+    /**
+     * Create agents of the same type by using their factory.
+     * @param token the token id of their factory
+     */
+    public boolean createAgents(int token, long count) {
+        Optional<List<Agent>> agents = this.registryFactories.createSwarm(token, count);
+
+        if (agents.isPresent()) {
+            this.agentList.addAll(agents.get());
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Create an agent by using his factory
+     * @param token the token id of his factory
+     */
+    public boolean createAgent(int token) {
+        Optional<Agent> agent = this.registryFactories.createAgent(token);
+
+        if (agent.isPresent()) {
+            this.agentList.add(agent.get());
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/ProjetINFRA/src/test/java/fr/m2dl/infra/AgentFactoriesRegistryTest.java
+++ b/ProjetINFRA/src/test/java/fr/m2dl/infra/AgentFactoriesRegistryTest.java
@@ -1,0 +1,102 @@
+package fr.m2dl.infra;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import fr.m2dl.infra.examples.AgentTest;
+import fr.m2dl.infra.examples.FactoryForAgentTest;
+import fr.m2dl.infra.examplesForACO.Ant;
+import fr.m2dl.infra.examplesForACO.FactoryForAnt;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class AgentFactoriesRegistryTest {
+
+    AgentFactoriesRegistry factoriesRegistry;
+
+    @Before
+    public void setUp() {
+        factoriesRegistry = new AgentFactoriesRegistry();
+    }
+
+    @Test
+    public void itShouldRegisterDifferentFactories () {
+        FactoryForAgentTest factoOfAgentTest = new FactoryForAgentTest();
+        FactoryForAnt factoOfAnt = new FactoryForAnt();
+
+        factoriesRegistry.registerAgentFactory(factoOfAgentTest);
+        factoriesRegistry.registerAgentFactory(factoOfAnt);
+
+        assertEquals(2, factoriesRegistry.getNbOfFactories());
+    }
+
+    @Test
+    public void itShouldRegisterSameFactoriesType() {
+        FactoryForAgentTest facto1 = new FactoryForAgentTest();
+        FactoryForAgentTest facto2 = new FactoryForAgentTest();
+        FactoryForAgentTest facto3 = new FactoryForAgentTest();
+
+        factoriesRegistry.registerAgentFactory(facto1);
+        factoriesRegistry.registerAgentFactory(facto2);
+        factoriesRegistry.registerAgentFactory(facto3);
+
+        assertEquals(3, factoriesRegistry.getNbOfFactories());
+    }
+
+    @Test
+    public void itShouldCreateDifferentAgentByUsingDifferentFactory () {
+        FactoryForAgentTest factoOfAgentTest = new FactoryForAgentTest();
+        FactoryForAnt factoOfAnt = new FactoryForAnt();
+        int tokenAgentTest, tokenAnt;
+
+        tokenAgentTest = factoriesRegistry.registerAgentFactory(factoOfAgentTest);
+        tokenAnt = factoriesRegistry.registerAgentFactory(factoOfAnt);
+
+        AgentTest agentTest = (AgentTest) factoriesRegistry.createAgent(tokenAgentTest).get();
+        Ant ant = (Ant) factoriesRegistry.createAgent(tokenAnt).get();
+
+        assertTrue(agentTest instanceof AgentTest);
+        assertTrue(ant instanceof Ant);
+    }
+
+    @Test
+    public void itShouldCreateAnAgentWhenTheFactoryExist () {
+        FactoryForAgentTest facto = new FactoryForAgentTest();
+
+        int tokenForFacto = factoriesRegistry.registerAgentFactory(facto);
+
+        assertTrue(factoriesRegistry.createAgent(tokenForFacto).isPresent());
+    }
+
+    @Test
+    public void itShouldCreateASwarmWhenTheFactoryExist () {
+        FactoryForAgentTest facto = new FactoryForAgentTest();
+        int numberOfAgentToSpawn = 10;
+        int tokenForFacto;
+        
+        tokenForFacto = factoriesRegistry.registerAgentFactory(facto);
+
+        factoriesRegistry.createSwarm(tokenForFacto, numberOfAgentToSpawn)
+            .ifPresent(agents -> {
+                assertEquals(numberOfAgentToSpawn, agents.size());
+                assertTrue(agents.get(0) instanceof AgentTest);
+            });
+    }
+
+    @Test
+    public void itShouldCreateNotCreateAnAgentWhenFactoryIsNotRegister () {
+        int dumbToken = 125;
+
+        assertFalse(factoriesRegistry.createAgent(dumbToken).isPresent());
+    }
+
+    @Test
+    public void itShouldCreateNotCreateASwarmWhenFactoryIsNotRegister () {
+        int dumbToken = 125;
+
+        assertFalse(factoriesRegistry.createSwarm(dumbToken, 3).isPresent());
+    }
+
+}

--- a/ProjetINFRA/src/test/java/fr/m2dl/infra/examples/FactoryForAgentTest.java
+++ b/ProjetINFRA/src/test/java/fr/m2dl/infra/examples/FactoryForAgentTest.java
@@ -1,0 +1,11 @@
+package fr.m2dl.infra.examples;
+
+import fr.m2dl.infra.IFactoryAgent;
+
+public class FactoryForAgentTest implements IFactoryAgent<AgentTest> {
+
+    @Override
+    public AgentTest create() {
+        return new AgentTest(null);
+    }
+}

--- a/ProjetINFRA/src/test/java/fr/m2dl/infra/examplesForACO/FactoryForAnt.java
+++ b/ProjetINFRA/src/test/java/fr/m2dl/infra/examplesForACO/FactoryForAnt.java
@@ -1,0 +1,11 @@
+package fr.m2dl.infra.examplesForACO;
+
+import fr.m2dl.infra.IFactoryAgent;
+
+public class FactoryForAnt implements IFactoryAgent<Ant> {
+
+    @Override
+    public Ant create() {
+        return new Ant(null);
+    }
+}


### PR DESCRIPTION
The idea is to implement `AbstractFactory` which can create `Agent` and register them to the `Orchestrator`. We delegate the creation of agents to `Orchestrator`.